### PR TITLE
fix: change visibility of state_cache_size in import_params

### DIFF
--- a/substrate/client/cli/src/params/import_params.rs
+++ b/substrate/client/cli/src/params/import_params.rs
@@ -83,7 +83,7 @@ pub struct ImportParams {
 
 	/// DEPRECATED: switch to `--trie-cache-size`.
 	#[arg(long)]
-	state_cache_size: Option<usize>,
+	pub state_cache_size: Option<usize>,
 }
 
 impl ImportParams {


### PR DESCRIPTION
(cherry picked from commit b12526cdbcd72b2e98c06fffcaed38997ce430e0)

Using this branch in the `config-refactor` branch of midnight-node repo