### PR TITLE
[ETCM-8147] revert bandersnatch removal

### DIFF
--- a/substrate/primitives/consensus/sassafras/Cargo.toml
+++ b/substrate/primitives/consensus/sassafras/Cargo.toml
@@ -22,9 +22,9 @@ codec = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
 serde = { features = ["derive"], optional = true, workspace = true }
 sp-api.workspace = true
-sp-application-crypto.workspace = true
+sp-application-crypto = { features = ["bandersnatch-experimental"], workspace = true }
 sp-consensus-slots.workspace = true
-sp-core.workspace = true
+sp-core = { features = ["bandersnatch-experimental"], workspace = true }
 sp-runtime.workspace = true
 
 [features]


### PR DESCRIPTION
In order to make our polkadot-sdk diff to upstream smaller, I've reverted our bandersnatch feature removal.
I've tested depending on this version and it doesn't add any problematic dependencies to Cargo.lock downstream nor fail the build. It seems upstream has fixed the root cause.